### PR TITLE
Fix server validity check, insert English description

### DIFF
--- a/mastodon/index.js
+++ b/mastodon/index.js
@@ -4,7 +4,7 @@ module.exports = (Franz) => {
       const api = `${URL}/manifest.json`;
       return new Promise((resolve, reject) => {
         $.get(api, (resp) => {
-          if (typeof(resp) === 'object' && 'name' in resp && resp.name === 'Mastodon') {
+          if (typeof(resp) === 'object' && 'name' in resp) {
             resolve();
           }else{
             reject();

--- a/mastodon/package.json
+++ b/mastodon/package.json
@@ -8,7 +8,7 @@
   "config": {
     "serviceURL": "",
     "serviceName": "Mastodon",
-    "message": "Mastodon est un serveur libre de réseautage social.",
+    "message": "Mastodon is a free social networking system.",
     "popup": [],
     "hasNotificationSound": true,
     "hasIndirectMessages": false,


### PR DESCRIPTION
Mastodonプラグインで新しいサーバーを追加する際、name === 'Mastodon'という、現在の多くのインスタンスで必ずしも真にならない条件をチェックしておりサーバー追加ができなくなっていたため、条件を緩和して修正しました。